### PR TITLE
define the vairable as None in codepath

### DIFF
--- a/ckanext/berlinauth/auth/get.py
+++ b/ckanext/berlinauth/auth/get.py
@@ -110,7 +110,7 @@ def user_show(context, data_dict):
     - everyone: only allow to see self
     - sysadmin: can see everyone
     """
-
+    user_obj = None
     model = context['model']
 
     _id = data_dict.get('id', None)


### PR DESCRIPTION
There is a bug in our custom user_show() auth method (undefined variable). This PR fixes that.